### PR TITLE
add build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
   "files": [
     "dist/**/*.js"
   ],
+  "scripts": {
+    "build": "rollup -c"
+  },
   "main": "dist/druid.js",
-  "unpkg": "dist/druid.js",
-  "jsdelivr": "dist/druid.js",
+  "unpkg": "dist/druid.min.js",
+  "jsdelivr": "dist/druid.min.js",
   "module": "dist/druid.esm.js",
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
@@ -37,6 +40,6 @@
     "tape": "^4.13.3"
   },
   "engines": {
-    "node": ">=14.12.0"
+    "node": ">=14"
   }
 }


### PR DESCRIPTION
Notes:
- build with `yarn build` or `npm run build`
- the repo currently has both package-lock.json and yarn-lock, you should chose one of them :)
- it would be great to run tests by calling `yarn test`
- there's no need to have the dist/ directory in github