### PR TITLE
use rdist (euclidian_squared) in UMAP's optimize_layout

### DIFF
--- a/dimred/UMAP.js
+++ b/dimred/UMAP.js
@@ -1,5 +1,5 @@
 import { Matrix } from "../matrix/index";
-import { euclidean } from "../metrics/index";
+import { euclidean, euclidean_squared } from "../metrics/index";
 import { BallTree } from "../knn/index";
 import { neumair_sum } from "../numerical/index";
 import { linspace } from "../matrix/index";
@@ -262,7 +262,7 @@ export class UMAP extends DR {
                 const k = tail[i];
                 const current = head_embedding.row(j);
                 const other = tail_embedding.row(k);
-                const dist = euclidean(current, other)//this._metric(current, other);
+                const dist = euclidean_squared(current, other)//this._metric(current, other);
                 let grad_coeff = 0;
                 if (dist > 0) {
                     grad_coeff = (-2 * a * b * Math.pow(dist, b - 1)) / (a * Math.pow(dist, b) + 1);
@@ -281,7 +281,7 @@ export class UMAP extends DR {
                 for (let p = 0; p < n_neg_samples; ++p) {
                     const k = Math.floor(this._randomizer.random * tail_length);
                     const other = tail_embedding.row(tail[k]);
-                    const dist = euclidean(current, other)//this._metric(current, other);
+                    const dist = euclidean_squared(current, other)//this._metric(current, other);
                     let grad_coeff = 0;
                     if (dist > 0) {
                         grad_coeff = (2 * repulsion_strength * b) / ((.01 + dist) * (a * Math.pow(dist, b) + 1));


### PR DESCRIPTION
I saw this difference when comparing optimize_layout in [python](https://github.com/lmcinnes/umap/blob/master/umap/layouts.py#L112) and in druidjs.
The layout is nicer with rdist.

before:
<img width="514" alt="before" src="https://user-images.githubusercontent.com/7001/97541251-1f575180-19c5-11eb-883f-b2afb7b64346.png">


after:
<img width="514" alt="after" src="https://user-images.githubusercontent.com/7001/97541255-21211500-19c5-11eb-9c4b-e353fb7b04f8.png">

