### PR TITLE
Return UMAP graph (Experimental!)

### DIFF
--- a/dimred/UMAP.js
+++ b/dimred/UMAP.js
@@ -218,6 +218,11 @@ export class UMAP extends DR {
         return this._min_dist;
     }
 
+    graph() {
+        this.check_init();
+        return { cols: this._head, rows: this._tail, weights: this._weights };
+    }
+
     transform(iterations) {
         this.check_init();
         iterations = iterations || this._n_epochs;

--- a/dimred/UMAP.js
+++ b/dimred/UMAP.js
@@ -155,7 +155,7 @@ export class UMAP extends DR {
     }
 
     _make_epochs_per_sample(graph, n_epochs) {
-        const { data: weights } = this._tocoo(graph);
+        const weights = this._weights;
         const result = new Float32Array(weights.length).fill(-1);
         const weights_max = max(weights);
         const n_samples = weights.map(w => n_epochs * (w / weights_max));
@@ -191,13 +191,14 @@ export class UMAP extends DR {
         this._a = a;
         this._b = b;
         this._graph = this._fuzzy_simplicial_set(this.X, this._n_neighbors);
+        const { rows, cols, data: weights } = this._tocoo(this._graph);
+        this._head = rows;
+        this._tail = cols;
+        this._weights = weights;
         this._epochs_per_sample = this._make_epochs_per_sample(this._graph, this._n_epochs);
         this._epochs_per_negative_sample = this._epochs_per_sample.map(d => d * this._negative_sample_rate);
         this._epoch_of_next_sample = this._epochs_per_sample.slice();
         this._epoch_of_next_negative_sample = this._epochs_per_negative_sample.slice();
-        const { rows, cols } = this._tocoo(this._graph);
-        this._head = rows;
-        this._tail = cols;
         return this;
     }
 

--- a/dimred/UMAP.js
+++ b/dimred/UMAP.js
@@ -139,7 +139,7 @@ export class UMAP extends DR {
         const knn = new BallTree(X.to2dArray, euclidean);
         let { distances, sigmas, rhos } = this._smooth_knn_dist(knn, n_neighbors);
         distances = this._compute_membership_strengths(distances, sigmas, rhos);
-        let result = new Matrix(X.shape[0], X.shape[0], "zeros");
+        const result = new Matrix(X.shape[0], X.shape[0], "zeros");
         for (let i = 0, n = X.shape[0]; i < n; ++i) {
             for (let j = 0; j < n_neighbors; ++j) {
                 result.set_entry(i, distances[i][j].element.index, distances[i][j].value);
@@ -147,20 +147,20 @@ export class UMAP extends DR {
         }
         const transposed_result = result.T;
         const prod_matrix = result.mult(transposed_result);
-        result = result
+        return result
             .add(transposed_result)
             .sub(prod_matrix)
             .mult(this._set_op_mix_ratio)
             .add(prod_matrix.mult(1 - this._set_op_mix_ratio));
-        return result;
     }
 
     _make_epochs_per_sample(graph, n_epochs) {
         const { data: weights } = this._tocoo(graph);
-        let result = new Array(weights.length).fill(-1);
+        const result = new Float32Array(weights.length).fill(-1);
         const weights_max = max(weights);
         const n_samples = weights.map(w => n_epochs * (w / weights_max));
-        result = result.map((d, i) => (n_samples[i] > 0) ? Math.round(n_epochs / n_samples[i]) : d);
+        for (let i = 0; i < result.length; ++i) 
+          if (n_samples[i] > 0) result[i] = Math.round(n_epochs / n_samples[i]);
         return result;
     }
 

--- a/dimred/UMAP.js
+++ b/dimred/UMAP.js
@@ -5,6 +5,7 @@ import { neumair_sum } from "../numerical/index";
 import { linspace } from "../matrix/index";
 import { powell } from "../optimization/index";
 import { DR } from "./DR.js";
+import { max } from "../util/index";
 
 export class UMAP extends DR {
     constructor(X, local_connectivity=1, min_dist=1, d=2, metric=euclidean, seed=1212) {
@@ -157,7 +158,7 @@ export class UMAP extends DR {
     _make_epochs_per_sample(graph, n_epochs) {
         const { data: weights } = this._tocoo(graph);
         let result = new Array(weights.length).fill(-1);
-        const weights_max = Math.max(...weights);
+        const weights_max = max(weights);
         const n_samples = weights.map(w => n_epochs * (w / weights_max));
         result = result.map((d, i) => (n_samples[i] > 0) ? Math.round(n_epochs / n_samples[i]) : d);
         return result;

--- a/dimred/UMAP.js
+++ b/dimred/UMAP.js
@@ -1,5 +1,5 @@
 import { Matrix } from "../matrix/index";
-import { euclidean } from "../metrics/index";
+import { euclidean, euclidean_squared } from "../metrics/index";
 import { BallTree } from "../knn/index";
 import { neumair_sum } from "../numerical/index";
 import { linspace } from "../matrix/index";
@@ -262,7 +262,7 @@ export class UMAP extends DR {
                 const k = tail[i];
                 const current = head_embedding.row(j);
                 const other = tail_embedding.row(k);
-                const dist = euclidean(current, other)//this._metric(current, other);
+                const dist = euclidean_squared(current, other)//this._metric(current, other);
                 let grad_coeff = 0;
                 if (dist > 0) {
                     grad_coeff = (-2 * a * b * Math.pow(dist, b - 1)) / (a * Math.pow(dist, b) + 1);
@@ -281,7 +281,7 @@ export class UMAP extends DR {
                 for (let p = 0; p < n_neg_samples; ++p) {
                     const k = Math.floor(this._randomizer.random * tail_length);
                     const other = tail_embedding.row(tail[k]);
-                    const dist = euclidean(current, other)//this._metric(current, other);
+                    const dist = euclidean_squared(current, other)//this._metric(current, other);
                     let grad_coeff = 0;
                     if (dist > 0) {
                         grad_coeff = (2 * repulsion_strength * b) / ((.01 + dist) * (a * Math.pow(dist, b) + 1));

--- a/util/index.js
+++ b/util/index.js
@@ -1,1 +1,2 @@
-export { Randomizer } from "./randomizer"
+export { Randomizer } from "./randomizer";
+export { max } from "./max";

--- a/util/max.js
+++ b/util/max.js
@@ -1,0 +1,10 @@
+export function max(values) {
+  let max;
+  for (const value of values) {
+    if (value != null
+        && (max < value || (max === undefined && value >= value))) {
+      max = value;
+    }
+  }
+  return max;
+}


### PR DESCRIPTION
This branch allows to return the UMAP graph. I don't like the API but wanted to share the concept with you. (It also contains a few optimizations I saw in passing.)

An application / use case is to compute the positions with d3-force rather than with the original UMAP's optimize_layout:

![Enregistrement de l’écran 2020-10-29 à 15 09 05](https://user-images.githubusercontent.com/7001/97585058-02d50c80-19f9-11eb-9754-f3c3d509be78.gif)

I think it looks much nicer (smooooooth movements), and the approach also allows to add other types of forces (forceCollide and so on), reuse the previous positions when the underlying data changes, allow direct interaction with the mouse, and so on.

I would however understand if you consider this to be out of scope :)

x-Ref: https://github.com/lmcinnes/umap/issues/509#issuecomment-718777075