### PR TITLE
SAMMON: set _is_initialized as true after init()

### DIFF
--- a/src/dimred/SAMMON.js
+++ b/src/dimred/SAMMON.js
@@ -36,6 +36,7 @@ export class SAMMON extends DR {
      * @private
      */
     init() {
+        if (this._is_initialized) return this;
         const N = this.X.shape[0];
         const { d, metric, init_DR: init_DR, init_parameters: DR_parameters } = this._parameters;
         if (init_DR === "random") {
@@ -47,6 +48,7 @@ export class SAMMON extends DR {
             throw new Error('init_DR needs to be either "random" or a DR method!');
         }
         this.distance_matrix = metric == "precomputed" ? Matrix.from(this.X) : distance_matrix(this.X, metric);
+        this._is_initialized = true;
         return this;
     }
 

--- a/test/dr.js
+++ b/test/dr.js
@@ -243,6 +243,9 @@ describe("DR techniques", () => {
         const dr = new druid.SAMMON(X, { d: 2, metric: druid.manhattan, init_DR: "PCA" });
         assert.ok(dr.para("magic", 0.6));
         assert.ok(dr.p("magic", 0.5));
+        assert.equal(dr._is_initialized, false);
+        assert.ok(dr.init());
+        assert.equal(dr._is_initialized, true);
         assert.ok(dr.transform());
 
         let generator;


### PR DESCRIPTION
In Sammon's Mapping, property `_is_initialized` is not being set to `true` in the `init()` method. This property is `false` by default.

When `transform()` or `generator()` methods are called and return `this.projection`, the `get projection()` from class `DR` will check `_is_initialized` and, as it's `false`, will call the `init()` method again, thus replacing the values computed for the projection with the initial values.

Setting `_is_initialized` as `true` in the end of the `init()` method fix this problem.